### PR TITLE
Unblock NCSI

### DIFF
--- a/windowsblock.txt
+++ b/windowsblock.txt
@@ -59,8 +59,6 @@ h2.msn.com
 hostedocsp.globalsign.com
 i1.services.social.microsoft.com
 i1.services.social.microsoft.com.nsatc.net
-ipv6.msftncsi.com
-ipv6.msftncsi.com.edgesuite.net
 lb1.www.ms.akadns.net
 live.rads.msn.com
 m.adnxs.com
@@ -108,10 +106,8 @@ watson.telemetry.microsoft.com.nsatc.net
 win10.ipv6.microsoft.com
 www.bingads.microsoft.com
 www.go.microsoft.akadns.net
-www.msftncsi.com
 client.wns.windows.com
 wdcp.microsoft.com
-dns.msftncsi.com
 wdcpalt.microsoft.com
 settings-ssl.xboxlive.com
 settings-ssl.xboxlive.com-c.edgekey.net


### PR DESCRIPTION
Your list is blocking Microsoft NCSI (`*.msftncsi.com`), making Windows believe that internet connection isn't available. This breaks OneDrive, as it refuses to sync, as well as confusing users. In this pull request I remove those domains because of that.

Domains taken from [official MS site](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-vista/cc766017(v=ws.10)) through [superuser](https://superuser.com/questions/277923/how-does-windows-know-whether-it-has-internet-access-or-if-a-wi-fi-connection-re)